### PR TITLE
tests: refactor tests and add GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,17 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: get todays date
-        id: date
-        run: |
-          echo "value=$(date +%F)" >> $GITHUB_OUTPUT
-
-      - name: neovim cache
-        uses: actions/cache@v4
-        with:
-          path: _nvim
-          key: ${{ runner.os }}-nvim-${{ steps.date.outputs.value }}
-
       - name: plugins cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,48 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    paths:
+      - ".github/workflows/test.yaml"
+      - "Makefile"
+      - "lua/**"
+      - "tests/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: get todays date
+        id: date
+        run: |
+          echo "value=$(date +%F)" >> $GITHUB_OUTPUT
+
+      - name: neovim cache
+        uses: actions/cache@v4
+        with:
+          path: _nvim
+          key: ${{ runner.os }}-nvim-${{ steps.date.outputs.value }}
+
+      - name: plugins cache
+        uses: actions/cache@v4
+        with:
+          path: .tests
+          key: ${{ runner.os }}-plugins-${{ hashFiles('tests/busted.lua') }}
+
+      - name: setup neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: nightly
+
+      - name: run tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 test:
 	@echo "Running tests..."
 	nvim -l tests/busted.lua tests
-	rm -rf -v tests/.tmp_projects
+	rm -rfv tests/.tmp_projects
 
 .PHONY: clean-test
 clean-test:

--- a/lua/js-i18n/translation-source.lua
+++ b/lua/js-i18n/translation-source.lua
@@ -34,7 +34,7 @@ function M.update_translation(file, key, text)
   local key_str = vim
     .iter(key)
     :map(function(k)
-      return string.format('["%s"]', k)
+      return string.format('"%s"', k)
     end)
     :join(".")
 

--- a/lua/js-i18n/translation-source.lua
+++ b/lua/js-i18n/translation-source.lua
@@ -53,7 +53,7 @@ function M.update_translation(file, key, text)
 
   local output = vim.fn.system(cmd)
   if output ~= "" and vim.v.shell_error ~= 0 then
-    vim.notify("Error updating translation:\n" .. output, vim.log.levels.ERROR)
+    vim.notify("Error updating translation: " .. output, vim.log.levels.ERROR)
     -- tmp ファイルが残っているため削除
     vim.fn.delete(file .. ".tmp")
   end

--- a/tests/helper.lua
+++ b/tests/helper.lua
@@ -20,6 +20,13 @@ M.teardown = function()
   _G._TEST = nil
 end
 
+--- プラグインをクリーンアップする
+M.clean_plugin = function()
+  -- プラグインの再読み込み
+  -- メッセージが表示されないように、:Lazy reload は使わず内部の関数を直接呼ぶ。
+  require("lazy.core.loader").reload("js-i18n.nvim")
+end
+
 local test_template_project_root_path = "tests/projects"
 local test_project_root_path = "tests/.tmp_projects"
 


### PR DESCRIPTION
#  Description generated by Copilot

This commit includes several changes to improve the testing infrastructure:

1. Refactor the tests in `command_spec.lua` to use a table-driven approach, making it easier to add new test cases in the future.

2. Add a new helper function `clean_plugin` in `helper.lua` to reload the plugin before each test.

3. Add a new GitHub Actions workflow in `.github/workflows/test.yaml` to run the tests on every push and pull request.

4. Make a minor change in the `Makefile` to use the `-v` (verbose) option with `rm`.

This should make the tests more maintainable and the results more visible to contributors.