### PR TITLE
fix(translation-source): add fast event check for file read

### DIFF
--- a/lua/js-i18n/translation-source.lua
+++ b/lua/js-i18n/translation-source.lua
@@ -160,6 +160,13 @@ end
 --- @param file string ファイルパス
 --- @param callback fun(err: string | nil, json: table | nil) コールバック
 function TranslationSource:read_translation_file(file, callback)
+  if vim.in_fast_event() then
+    vim.schedule(function()
+      self:read_translation_file(file, callback)
+    end)
+    return
+  end
+
   local path = Path:new(file)
 
   if not path:exists() then


### PR DESCRIPTION
# Description (generated by Copilot)

This commit introduces a check for vim's fast event before reading a translation file. If in a fast event, the read operation is scheduled to run later. This prevents potential issues with file read operations during fast events.