### PR TITLE
fix: Virtual text is broken when the t-function is used for the value of the t-function options.

### DIFF
--- a/lua/js-i18n/analyzer.lua
+++ b/lua/js-i18n/analyzer.lua
@@ -176,15 +176,17 @@ local function parse_call_t(target_node, bufnr, query)
   for id, node, _ in query:iter_captures(target_node, bufnr, 0, -1) do
     local name = query.captures[id]
 
+    -- t関数の呼び出しがネストしている場合があるため、最初に見つかったものを採用する
+    -- そのため key = ke or ... のような形にしている
     if name == "i18n.key" then
-      key = vim.treesitter.get_node_text(node, bufnr)
-      key_node = node
+      key = key or vim.treesitter.get_node_text(node, bufnr)
+      key_node = key_node or node
     elseif name == "i18n.key_arg" then
-      key_arg_node = node
+      key_arg_node = key_arg_node or node
     elseif name == "i18n.namespace" then
-      namespace = vim.treesitter.get_node_text(node, bufnr)
+      namespace = namespace or vim.treesitter.get_node_text(node, bufnr)
     elseif name == "i18n.key_prefix" then
-      key_prefix = vim.treesitter.get_node_text(node, bufnr)
+      key_prefix = key_prefix or vim.treesitter.get_node_text(node, bufnr)
     end
   end
 

--- a/tests/js-i18n/analyzer_spec.lua
+++ b/tests/js-i18n/analyzer_spec.lua
@@ -157,6 +157,20 @@ describe("analyzer.find_call_t_expressions", function()
     for _, test in ipairs(tests) do
       test_find_t_call(get_project, test.text, false)
     end
+
+    it("should find \"t\" function calls in \"t('key1', { value: t('key2') })\"", function()
+      -- Arrange
+      vim.cmd("e " .. project.path .. "/index.js")
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "t('key1', { value: t('key2') })" })
+
+      -- Act
+      local result = analyzer.find_call_t_expressions(0)
+
+      -- Assert
+      assert.are.equal(2, #result)
+      assert.are.same("key1", result[1].key)
+      assert.are.same("key2", result[2].key)
+    end)
   end)
 
   describe("when using 'next-intl'", function()


### PR DESCRIPTION
close #28 

Ensure that the first found key, key_arg, namespace, and key_prefix are used when t function calls are nested. Added a test case to verify the correct behavior with nested t function calls.