### PR TITLE
feat: add support for namespace-based file structure

### DIFF
--- a/lua/js-i18n/analyzer.lua
+++ b/lua/js-i18n/analyzer.lua
@@ -335,6 +335,12 @@ function M.find_call_t_expressions(bufnr)
         key = key_prefix .. c.config.key_separator .. key
       end
 
+      local namespace = nil
+      if c.config.namespace_separator ~= nil then
+        local split_key = vim.split(key, c.config.namespace_separator, { plain = true })
+        namespace = split_key[1]
+      end
+
       table.insert(result, {
         node = node,
         key_node = call_t_detail.key_node,
@@ -342,7 +348,7 @@ function M.find_call_t_expressions(bufnr)
         key = key,
         key_prefix = key_prefix,
         key_arg = call_t_detail.key,
-        namespace = call_t_detail.namespace or scope.namespace,
+        namespace = call_t_detail.namespace or namespace or scope.namespace,
       })
     end
     ::continue::

--- a/lua/js-i18n/client.lua
+++ b/lua/js-i18n/client.lua
@@ -227,11 +227,30 @@ function Client:edit_translation(lang, key)
       return
     end
 
+    local namespace = nil
+
+    if c.config.namespace_separator ~= nil then
+      local split_first_key = vim.split(split_key[1], c.config.namespace_separator, { plain = true })
+      namespace = split_first_key[1]
+      split_key[1] = split_first_key[2]
+    end
+
     -- キーに一致する文言があれば編集、なければ追加
-    local old_translation, file = ws_t_source:get_translation(lang, split_key)
+    local old_translation, file = ws_t_source:get_translation(lang, split_key, nil, namespace)
     if not file then
       local sources = ws_t_source:get_translation_source_by_lang(lang)
-      local files = vim.tbl_keys(sources)
+
+      local all_files = vim.tbl_keys(sources)
+
+      local files = {}
+
+      local i = 1
+      for _, file in pairs(all_files) do
+        if namespace == nil or string.find(file, namespace .. ".json") then
+          files[i] = file
+          i = i + 1
+        end
+      end
 
       -- カレントディレクトリからの相対パスに変換
       files = vim.tbl_map(function(f)

--- a/lua/js-i18n/config.lua
+++ b/lua/js-i18n/config.lua
@@ -55,6 +55,7 @@ end
 --- @field primary_language string[] 優先表示する言語
 --- @field translation_source string[] 翻訳ソースのパターン
 --- @field detect_language fun(path: string): string ファイルパスから言語を検出する関数
+--- @field namespace_separator string?
 --- @field key_separator string キーのセパレータ
 --- @field virt_text I18n.VirtTextConfig バーチャルテキストの設定
 --- @field diagnostic I18n.Diagnostic 診断の設定
@@ -78,6 +79,7 @@ local default_config = {
   primary_language = {},
   translation_source = { "**/{locales,messages}/*.json" },
   detect_language = M.default_detect_language,
+  namespace_separator = nil,
   key_separator = ".",
   virt_text = {
     enabled = true,

--- a/lua/js-i18n/init.lua
+++ b/lua/js-i18n/init.lua
@@ -32,6 +32,10 @@ i18n.client = nil
 --- setup
 --- @param opts I18n.Config
 i18n.setup = function(opts)
+  local hl = vim.api.nvim_set_hl
+
+  hl(0, '@i18n.translation', { link = 'Comment' })
+
   local group = vim.api.nvim_create_augroup("js-i18n", {})
   -- 設定の初期化
   c.setup(opts)

--- a/lua/js-i18n/lsp/checker.lua
+++ b/lua/js-i18n/lsp/checker.lua
@@ -33,10 +33,18 @@ function M.check(client, uri)
     local key = t_call.key
     local keys = vim.split(key, c.config.key_separator, { plain = true })
 
+    local namespace = nil
+
+    if c.config.namespace_separator ~= nil then
+      local split_first_key = vim.split(keys[1], c.config.namespace_separator, { plain = true })
+      namespace = split_first_key[1]
+      keys[1] = split_first_key[2]
+    end
+
     local missing_languages = {}
     local available_languages = t_source:get_available_languages()
     for _, lang in ipairs(available_languages) do
-      local translation = t_source:get_translation(lang, keys, library)
+      local translation = t_source:get_translation(lang, keys, library, namespace)
       if not translation then
         table.insert(missing_languages, lang)
       end

--- a/lua/js-i18n/lsp/protocol/request/text_document_hover.lua
+++ b/lua/js-i18n/lsp/protocol/request/text_document_hover.lua
@@ -26,11 +26,19 @@ local function handler(params, client)
 
   local library = utils.detect_library(bufnr)
 
+  local namespace = nil
+
+  if c.config.namespace_separator ~= nil then
+    local split_first_key = vim.split(keys[1], c.config.namespace_separator, { plain = true })
+    namespace = split_first_key[1]
+    keys[1] = split_first_key[2]
+  end
+
   -- 各言語の翻訳を表示
   --- @type string[]
   local contents = {}
   for _, lang in ipairs(t_source:get_available_languages()) do
-    local translation = t_source:get_translation(lang, keys, library)
+    local translation = t_source:get_translation(lang, keys, library, namespace)
     if translation then
       if type(translation) == "string" then
         table.insert(contents, lang .. ": `" .. translation .. "`")

--- a/lua/js-i18n/translation-source.lua
+++ b/lua/js-i18n/translation-source.lua
@@ -214,22 +214,25 @@ end
 --- @param lang string 言語
 --- @param key string[] キー
 --- @param library? string ライブラリ
+--- @param namespace? string
 --- @return any|string|nil translation 文言
 --- @return string|nil file 文言リソース
-function TranslationSource:get_translation(lang, key, library)
+function TranslationSource:get_translation(lang, key, library, namespace)
   for file, json in pairs(self:get_translation_source_by_lang(lang)) do
-    local text = vim.tbl_get(json, unpack(key))
-    if text then
-      return text, file
-    end
+    if namespace == nil or string.find(file, namespace .. ".json") then
+      local text = vim.tbl_get(json, unpack(key))
+      if text then
+        return text, file
+      end
 
-    if library == utils.Library.I18Next then
-      for _, suffix in ipairs(c.config.libraries.i18next.plural_suffixes) do
-        local key_with_suffix = { unpack(key) }
-        key_with_suffix[#key_with_suffix] = key_with_suffix[#key_with_suffix] .. suffix
-        text = vim.tbl_get(json, unpack(key_with_suffix))
-        if text then
-          return text, file
+      if library == utils.Library.I18Next then
+        for _, suffix in ipairs(c.config.libraries.i18next.plural_suffixes) do
+          local key_with_suffix = { unpack(key) }
+          key_with_suffix[#key_with_suffix] = key_with_suffix[#key_with_suffix] .. suffix
+          text = vim.tbl_get(json, unpack(key_with_suffix))
+          if text then
+            return text, file
+          end
         end
       end
     end

--- a/lua/js-i18n/virt_text.lua
+++ b/lua/js-i18n/virt_text.lua
@@ -36,7 +36,15 @@ local function get_translation(lang, key, t_source, library)
 
   for _, l in ipairs(langs) do
     local split_key = vim.split(key, c.config.key_separator, { plain = true })
-    local text = t_source:get_translation(l, split_key, library)
+
+    local namespace = nil
+    if c.config.namespace_separator ~= nil then
+      local split_first_key = vim.split(split_key[1], c.config.namespace_separator, { plain = true })
+      namespace = split_first_key[1]
+      split_key[1] = split_first_key[2]
+    end
+
+    local text = t_source:get_translation(l, split_key, library, namespace)
     if text ~= nil and type(text) == "string" then
       return text, l
     end
@@ -76,7 +84,7 @@ function M.set_extmark(bufnr, current_language, t_source)
       config = c.config,
     })
     if type(virt_text) == "string" then
-      virt_text = { { virt_text, "Comment" } }
+      virt_text = { { virt_text, "@i18n.translation" } }
     end
 
     if c.config.virt_text.conceal_key then


### PR DESCRIPTION
Adds support for namespace-based translations, e.g. those using a format of:

```javascript
t('namespace:some.key.path');
```

If `namespace_separator` is set to `:`, for example. By default, it is `nil`, which preserves the current behavior.

And a folder structure similar to this:

```
./locales/[language]/[namespace].json
```

Also sets the highlight for virtual text to `@i18n.translation` instead of `Comment`, and by default links it to `Comment` (so it's better overridable by the user).