### PR TITLE
feat: Implements go to references

### DIFF
--- a/lua/js-i18n/analyzer.lua
+++ b/lua/js-i18n/analyzer.lua
@@ -278,7 +278,7 @@ function M.find_call_t_expressions_(source, lib, lang)
 
   local tree = parser:parse()[1]
   local root_node = tree:root()
-  local language = parser:lang()
+  local language = lang or parser:lang()
 
   if not vim.tbl_contains({ "javascript", "typescript", "jsx", "tsx" }, language) then
     return {}

--- a/lua/js-i18n/analyzer.lua
+++ b/lua/js-i18n/analyzer.lua
@@ -92,7 +92,7 @@ function M.get_node_for_key(source, keys)
     local query = ts.query.parse("json", [[
       (pair
         key: (string) @key (#eq? @key "\"]] .. k .. [[\"")
-        value: [(object)(string)] @value
+        value: [(object)(array)(string)] @value
       )
     ]])
 

--- a/lua/js-i18n/analyzer.lua
+++ b/lua/js-i18n/analyzer.lua
@@ -347,7 +347,8 @@ function M.find_call_t_expressions_(bufnr)
     return {}
   end
 
-  local library = utils.detect_library(bufnr) or utils.Library.I18Next
+  local workspace_dir = utils.get_workspace_root(bufnr)
+  local library = utils.detect_library(workspace_dir) or utils.Library.I18Next
   local query_str = ""
   for _, query_file in ipairs(library_query[library][language] or library_query[library]["*"]) do
     local str = M.load_query_from_file(query_file)

--- a/lua/js-i18n/analyzer.lua
+++ b/lua/js-i18n/analyzer.lua
@@ -242,9 +242,9 @@ end
 --- t関数を含むノードを検索する
 --- @param bufnr integer バッファ番号
 --- @return FindTExpressionResultItem[]
-function M.find_call_t_expressions(bufnr)
+function M.find_call_t_expressions_from_buf(bufnr)
   local workspace_dir = utils.get_workspace_root(bufnr)
-  return M.find_call_t_expressions_(bufnr, utils.detect_library(workspace_dir))
+  return M.find_call_t_expressions(bufnr, utils.detect_library(workspace_dir))
 end
 
 --- @class FindTExpressionResultItem
@@ -261,7 +261,7 @@ end
 --- @param lib? string ライブラリ
 --- @param lang? string 言語
 --- @return FindTExpressionResultItem[]
-function M.find_call_t_expressions_(source, lib, lang)
+function M.find_call_t_expressions(source, lib, lang)
   local ok, parser = pcall(function()
     if type(source) == "string" then
       if lang == nil then
@@ -382,7 +382,7 @@ end
 --- @return boolean ok カーソルが t 関数の引数内にあるかどうか
 --- @return FindTExpressionResultItem | nil result カーソルが t 関数の引数内にある場合は t 関数の情報
 function M.check_cursor_in_t_argument(bufnr, position)
-  local t_calls = M.find_call_t_expressions(bufnr)
+  local t_calls = M.find_call_t_expressions_from_buf(bufnr)
 
   for _, t_call in ipairs(t_calls) do
     local key_arg_node = t_call.key_arg_node

--- a/lua/js-i18n/analyzer.lua
+++ b/lua/js-i18n/analyzer.lua
@@ -292,6 +292,9 @@ function M.find_call_t_expressions(source, lib, lang)
   end
 
   local query_str = ""
+  if type(library_query[lib]) ~= "table" then
+    return {}
+  end
   for _, query_file in ipairs(library_query[lib][language] or library_query[lib]["*"]) do
     local str = M.load_query_from_file(query_file)
     if str and type(str) == "string" and str ~= "" then

--- a/lua/js-i18n/init.lua
+++ b/lua/js-i18n/init.lua
@@ -74,6 +74,7 @@ i18n.setup = function(opts)
           "typescriptreact",
           "javascript.jsx",
           "typescript.tsx",
+          "json",
         },
         single_file_support = true,
       },

--- a/lua/js-i18n/lsp/checker.lua
+++ b/lua/js-i18n/lsp/checker.lua
@@ -10,7 +10,7 @@ function M.check(client, uri)
   local bufnr = vim.uri_to_bufnr(uri)
   local workspace_dir = utils.get_workspace_root(bufnr)
   local t_source = client.t_source_by_workspace[workspace_dir]
-  local library = utils.detect_library(bufnr)
+  local library = utils.detect_library(workspace_dir)
 
   local dispatchers = require("js-i18n.lsp.config").dispatchers
   if not dispatchers then

--- a/lua/js-i18n/lsp/checker.lua
+++ b/lua/js-i18n/lsp/checker.lua
@@ -28,7 +28,7 @@ function M.check(client, uri)
   --- @type lsp.Diagnostic[]
   local diagnostics = {}
 
-  local t_calls = analyzer.find_call_t_expressions(bufnr)
+  local t_calls = analyzer.find_call_t_expressions_from_buf(bufnr)
   for _, t_call in ipairs(t_calls) do
     local key = t_call.key
     local keys = vim.split(key, c.config.key_separator, { plain = true })

--- a/lua/js-i18n/lsp/config.lua
+++ b/lua/js-i18n/lsp/config.lua
@@ -3,4 +3,7 @@ local M = {}
 --- @type vim.lsp.rpc.Dispatchers
 M.dispatchers = nil
 
+--- @type table<string, I18n.ReferenceTable>
+M.ref_table_by_workspace = {}
+
 return M

--- a/lua/js-i18n/lsp/init.lua
+++ b/lua/js-i18n/lsp/init.lua
@@ -35,12 +35,14 @@ function M.create_rpc(dispatchers, client)
       --- @type I18n.lsp.ProtocolModule
       local protocol_module = module
 
-      local err, result = protocol_module.handler(params, client)
-      if err then
-        callback(err, nil)
-      else
-        callback(nil, result)
-      end
+      vim.schedule(function()
+        local err, result = protocol_module.handler(params, client)
+        if err then
+          callback(err, nil)
+        else
+          callback(nil, result)
+        end
+      end)
       return true
     end,
     notify = function(method, params)
@@ -52,7 +54,10 @@ function M.create_rpc(dispatchers, client)
       end
       --- @type I18n.lsp.NotifyProtocolModule
       local protocol_module = module
-      protocol_module.handler(params, client)
+
+      vim.schedule(function()
+        protocol_module.handler(params, client)
+      end)
       return true
     end,
     is_closing = function()

--- a/lua/js-i18n/lsp/protocol/notify/text_document_did_change.lua
+++ b/lua/js-i18n/lsp/protocol/notify/text_document_did_change.lua
@@ -1,9 +1,26 @@
+local lsp_config = require("js-i18n.lsp.config")
+local reference_table = require("js-i18n.reference_table")
+
 --- ハンドラ
 --- @param params lsp.DidChangeTextDocumentParams
 --- @param client I18n.Client
 local function handler(params, client)
   if #params.contentChanges ~= 0 then
     local uri = params.textDocument.uri
+
+    local bufnr = vim.uri_to_bufnr(uri)
+    local workspace_dir = require("js-i18n.utils").get_workspace_root(bufnr)
+    local ref_table = lsp_config.ref_table_by_workspace[workspace_dir]
+    if lsp_config.ref_table_by_workspace[workspace_dir] == nil then
+      local ref_table = reference_table.ReferenceTable.new({
+        workspace_dir = workspace_dir,
+      })
+      lsp_config.ref_table_by_workspace[workspace_dir] = ref_table
+      ref_table:load_all()
+    else
+      ref_table:load_path(vim.uri_to_fname(uri))
+    end
+
     vim.schedule(function()
       require("js-i18n.lsp.checker").check(client, uri)
     end)

--- a/lua/js-i18n/lsp/protocol/notify/text_document_did_change.lua
+++ b/lua/js-i18n/lsp/protocol/notify/text_document_did_change.lua
@@ -18,7 +18,7 @@ local function handler(params, client)
       lsp_config.ref_table_by_workspace[workspace_dir] = ref_table
       ref_table:load_all()
     else
-      ref_table:load_path(vim.uri_to_fname(uri))
+      ref_table:load_path(vim.uri_to_fname(uri), params.contentChanges[1].text)
     end
 
     vim.schedule(function()

--- a/lua/js-i18n/lsp/protocol/notify/text_document_did_open.lua
+++ b/lua/js-i18n/lsp/protocol/notify/text_document_did_open.lua
@@ -1,8 +1,23 @@
+local lsp_config = require("js-i18n.lsp.config")
+local reference_table = require("js-i18n.reference_table")
+local utils = require("js-i18n.utils")
+
 --- ハンドラ
 --- @param params lsp.DidOpenTextDocumentParams
 --- @param client I18n.Client
 local function handler(params, client)
   local uri = params.textDocument.uri
+
+  local bufnr = vim.uri_to_bufnr(uri)
+  local workspace_dir = require("js-i18n.utils").get_workspace_root(bufnr)
+  if lsp_config.ref_table_by_workspace[workspace_dir] == nil then
+    local ref_table = reference_table.ReferenceTable.new({
+      workspace_dir = workspace_dir,
+    })
+    lsp_config.ref_table_by_workspace[workspace_dir] = ref_table
+    ref_table:load_all()
+  end
+
   vim.schedule(function()
     require("js-i18n.lsp.checker").check(client, uri)
   end)

--- a/lua/js-i18n/lsp/protocol/request/initialize.lua
+++ b/lua/js-i18n/lsp/protocol/request/initialize.lua
@@ -15,6 +15,7 @@ local function handler(params, _client)
     capabilities = {
       textDocumentSync = 1,
       definitionProvider = true,
+      referencesProvider = true,
       hoverProvider = true,
       completionProvider = {},
       codeActionProvider = {},

--- a/lua/js-i18n/lsp/protocol/request/text_document_completion.lua
+++ b/lua/js-i18n/lsp/protocol/request/text_document_completion.lua
@@ -39,8 +39,9 @@ end
 --- @return lsp.CompletionItem[]
 local function get_completion_items(client, bufnr, t_call)
   local lang = client:get_language(bufnr)
-  local t_source = client.t_source_by_workspace[utils.get_workspace_root(bufnr)]
-  local library = utils.detect_library(bufnr)
+  local workspace_dir = utils.get_workspace_root(bufnr)
+  local t_source = client.t_source_by_workspace[workspace_dir]
+  local library = utils.detect_library(workspace_dir)
 
   local key_prefix = t_call.key_prefix or ""
 

--- a/lua/js-i18n/lsp/protocol/request/text_document_definition.lua
+++ b/lua/js-i18n/lsp/protocol/request/text_document_definition.lua
@@ -26,7 +26,7 @@ local function handler(params, client)
   end
 
   local key = t_call.key
-  local library = utils.detect_library(bufnr)
+  local library = utils.detect_library(workspace_dir)
 
   for file, _ in pairs(t_source:get_translation_source_by_lang(lang)) do
     local bufnr = vim.api.nvim_create_buf(false, true)

--- a/lua/js-i18n/lsp/protocol/request/text_document_hover.lua
+++ b/lua/js-i18n/lsp/protocol/request/text_document_hover.lua
@@ -24,7 +24,7 @@ local function handler(params, client)
   local key = t_call.key
   local keys = vim.split(key, c.config.key_separator, { plain = true })
 
-  local library = utils.detect_library(bufnr)
+  local library = utils.detect_library(workspace_dir)
 
   local namespace = nil
 

--- a/lua/js-i18n/lsp/protocol/request/text_document_references.lua
+++ b/lua/js-i18n/lsp/protocol/request/text_document_references.lua
@@ -5,10 +5,10 @@ local utils = require("js-i18n.utils")
 
 --- ハンドラ
 --- @param params lsp.ReferenceParams
---- @param client I18n.Client
+--- @param _client I18n.Client
 --- @return string | nil error
 --- @return lsp.Location[] | nil result
-local function handler(params, client)
+local function handler(params, _client)
   local bufnr = vim.uri_to_bufnr(params.textDocument.uri)
 
   local workspace_dir = utils.get_workspace_root(bufnr)

--- a/lua/js-i18n/lsp/protocol/request/text_document_references.lua
+++ b/lua/js-i18n/lsp/protocol/request/text_document_references.lua
@@ -1,6 +1,6 @@
 local analyzer = require("js-i18n.analyzer")
 local c = require("js-i18n.config")
-local reference_table = require("js-i18n.reference_table")
+local lsp_config = require("js-i18n.lsp.config")
 local utils = require("js-i18n.utils")
 
 --- ハンドラ
@@ -19,11 +19,7 @@ local function handler(params, client)
   end
 
   local key = table.concat(keys, c.config.key_separator)
-
-  local ref_table = reference_table.ReferenceTable.new({ workspace_dir = workspace_dir })
-  ref_table:load_all()
-  ref_table:wait_processed()
-  local refs = ref_table:find_by_key(key)
+  local refs = lsp_config.ref_table_by_workspace[workspace_dir]:find_by_key(key)
 
   local result = {}
   for _, ref in ipairs(refs) do

--- a/lua/js-i18n/lsp/protocol/request/text_document_references.lua
+++ b/lua/js-i18n/lsp/protocol/request/text_document_references.lua
@@ -23,15 +23,9 @@ local function handler(params, client)
 
   local result = {}
   for _, ref in ipairs(refs) do
-    local path = ref.path
-    local t_call = ref.t_call
-    local row_start, col_start, row_end, col_end = t_call.node:range()
     table.insert(result, {
-      uri = vim.uri_from_fname(path),
-      range = {
-        start = { line = row_start, character = col_start },
-        ["end"] = { line = row_end, character = col_end },
-      },
+      uri = ref.uri,
+      range = ref.range,
     })
   end
 

--- a/lua/js-i18n/lsp/protocol/request/text_document_references.lua
+++ b/lua/js-i18n/lsp/protocol/request/text_document_references.lua
@@ -1,8 +1,6 @@
-local Path = require("plenary.path")
-local scan = require("plenary.scandir")
-
 local analyzer = require("js-i18n.analyzer")
 local c = require("js-i18n.config")
+local reference_table = require("js-i18n.reference_table")
 local utils = require("js-i18n.utils")
 
 --- ハンドラ
@@ -22,8 +20,10 @@ local function handler(params, client)
 
   local key = table.concat(keys, c.config.key_separator)
 
-  analyzer.preload(bufnr)
-  local refs = analyzer.find_references_by_key(workspace_dir, key)
+  local ref_table = reference_table.ReferenceTable.new({ workspace_dir = workspace_dir })
+  ref_table:load_all()
+  ref_table:wait_processed()
+  local refs = ref_table:find_by_key(key)
 
   local result = {}
   for _, ref in ipairs(refs) do

--- a/lua/js-i18n/lsp/protocol/request/text_document_references.lua
+++ b/lua/js-i18n/lsp/protocol/request/text_document_references.lua
@@ -1,0 +1,49 @@
+local Path = require("plenary.path")
+local scan = require("plenary.scandir")
+
+local analyzer = require("js-i18n.analyzer")
+local c = require("js-i18n.config")
+local utils = require("js-i18n.utils")
+
+--- ハンドラ
+--- @param params lsp.ReferenceParams
+--- @param client I18n.Client
+--- @return string | nil error
+--- @return lsp.Location[] | nil result
+local function handler(params, client)
+  local bufnr = vim.uri_to_bufnr(params.textDocument.uri)
+
+  local workspace_dir = utils.get_workspace_root(bufnr)
+  local keys = analyzer.get_key_at_cursor(bufnr, params.position)
+
+  if not keys or #keys == 0 then
+    return nil, {}
+  end
+
+  local key = table.concat(keys, c.config.key_separator)
+
+  analyzer.preload(bufnr)
+  local refs = analyzer.find_references_by_key(workspace_dir, key)
+
+  local result = {}
+  for _, ref in ipairs(refs) do
+    local path = ref.path
+    local t_call = ref.t_call
+    local row_start, col_start, row_end, col_end = t_call.node:range()
+    table.insert(result, {
+      uri = vim.uri_from_fname(path),
+      range = {
+        start = { line = row_start, character = col_start },
+        ["end"] = { line = row_end, character = col_end },
+      },
+    })
+  end
+
+  return nil, result
+end
+
+--- @type I18n.lsp.ProtocolModule
+local M = {
+  handler = handler,
+}
+return M

--- a/lua/js-i18n/reference_table.lua
+++ b/lua/js-i18n/reference_table.lua
@@ -51,10 +51,22 @@ function ReferenceTable:load_path(path)
 
   self._ref_processing[path] = true
   vim.schedule(function()
-    local lang = vim.filetype.match({ filename = path }) or "typescriptreact"
+    local ft = vim.filetype.match({ filename = path }) or "typescriptreact"
+    local lang = (function()
+      if ft == "typescript" then
+        return "typescript"
+      elseif ft == "typescriptreact" then
+        return "typescript"
+      elseif ft == "javascript" then
+        return "javascript"
+      elseif ft == "javascriptreact" then
+        return "javascript"
+      end
+      return "typescript"
+    end)()
     local content = Path:new(path):read()
 
-    local result = analyzer.find_call_t_expressions_(content, lang, lib)
+    local result = analyzer.find_call_t_expressions_(content, lib, lang)
     self._ref_table[path] = result
 
     self._ref_processing[path] = false

--- a/lua/js-i18n/reference_table.lua
+++ b/lua/js-i18n/reference_table.lua
@@ -1,0 +1,14 @@
+--- 翻訳の参照テーブル
+--- @class I18n.ReferenceTable
+--- @field _ref_table table<string, table<string, FindTExpressionResultItem[]>>
+---
+local ReferenceTable = {}
+ReferenceTable.__index = ReferenceTable
+
+--- @return I18n.ReferenceTable
+function ReferenceTable.new()
+  local self = setmetatable({}, ReferenceTable)
+
+  self._ref_table = {}
+  return self
+end

--- a/lua/js-i18n/reference_table.lua
+++ b/lua/js-i18n/reference_table.lua
@@ -49,9 +49,7 @@ function ReferenceTable:load_all()
 end
 
 function ReferenceTable:load_path(path, content)
-  self._ref_processing[path] = true
   if path == nil or path == "" then
-    self._ref_processing[path] = false
     return
   end
   local lib = utils.detect_library(self.config.workspace_dir)
@@ -68,11 +66,14 @@ function ReferenceTable:load_path(path, content)
       elseif ft == "javascriptreact" then
         return "javascript"
       end
-      vim.notify("Unknown filetype: " .. ft, vim.log.levels.ERROR)
       return nil
     end)()
+    if lang == nil then
+      return
+    end
     content = content or Path:new(path):read()
 
+    self._ref_processing[path] = true
     local result = analyzer.find_call_t_expressions(content, lib, lang)
     self._ref_table[path] = vim
       .iter(result)

--- a/lua/js-i18n/reference_table.lua
+++ b/lua/js-i18n/reference_table.lua
@@ -56,17 +56,17 @@ function ReferenceTable:load_path(path)
       if ft == "typescript" then
         return "typescript"
       elseif ft == "typescriptreact" then
-        return "typescript"
+        return "tsx"
       elseif ft == "javascript" then
         return "javascript"
       elseif ft == "javascriptreact" then
         return "javascript"
       end
-      return "typescript"
+      return nil
     end)()
     local content = Path:new(path):read()
 
-    local result = analyzer.find_call_t_expressions_(content, lib, lang)
+    local result = analyzer.find_call_t_expressions(content, lib, lang)
     self._ref_table[path] = result
 
     self._ref_processing[path] = false
@@ -85,8 +85,12 @@ function ReferenceTable:wait_processed()
     if not processing then
       break
     end
-    vim.wait(100)
+    vim.wait(50)
   end
+end
+
+function ReferenceTable:is_processing(path)
+  return self._ref_processing[path] ~= nil and not self._ref_processing[path]
 end
 
 --- @class ReferenceTable__find_by_key_result
@@ -97,6 +101,7 @@ end
 --- @param key string キー
 --- @return ReferenceTable__find_by_key_result[]
 function ReferenceTable:find_by_key(key)
+  self:wait_processed()
   local result = {}
   for path, t_calls in pairs(self._ref_table) do
     for _, t_call in ipairs(t_calls) do

--- a/lua/js-i18n/reference_table.lua
+++ b/lua/js-i18n/reference_table.lua
@@ -6,10 +6,15 @@ local utils = require("js-i18n.utils")
 
 local M = {}
 
+--- @class I18n.Ref
+--- @field key string
+--- @field uri string
+--- @field range lsp.Range
+
 --- 翻訳の参照テーブル
 --- @class I18n.ReferenceTable
 --- @field workspace_dir string ワークスペースディレクトリ
---- @field _ref_table table<string, table<string, FindTExpressionResultItem[]>>
+--- @field _ref_table table<string, table<string, I18n.Ref[]>>
 --- @field _ref_processing table<string, boolean>
 --- @field config I18n.ReferenceTableConfig
 local ReferenceTable = {}
@@ -43,13 +48,14 @@ function ReferenceTable:load_all()
   })
 end
 
-function ReferenceTable:load_path(path)
+function ReferenceTable:load_path(path, content)
+  self._ref_processing[path] = true
   if path == nil or path == "" then
+    self._ref_processing[path] = false
     return
   end
   local lib = utils.detect_library(self.config.workspace_dir)
 
-  self._ref_processing[path] = true
   vim.schedule(function()
     local ft = vim.filetype.match({ filename = path }) or "typescriptreact"
     local lang = (function()
@@ -62,19 +68,37 @@ function ReferenceTable:load_path(path)
       elseif ft == "javascriptreact" then
         return "javascript"
       end
+      vim.notify("Unknown filetype: " .. ft, vim.log.levels.ERROR)
       return nil
     end)()
-    local content = Path:new(path):read()
+    content = content or Path:new(path):read()
 
     local result = analyzer.find_call_t_expressions(content, lib, lang)
-    self._ref_table[path] = result
+    self._ref_table[path] = vim
+      .iter(result)
+      :map(function(t_call)
+        local row_start, col_start, row_end, col_end = t_call.node:range()
+        return {
+          key = t_call.key,
+          uri = vim.uri_from_fname(path),
+          range = {
+            start = { line = row_start, character = col_start },
+            ["end"] = { line = row_end, character = col_end },
+          },
+        }
+      end)
+      :totable()
 
     self._ref_processing[path] = false
   end)
 end
 
 function ReferenceTable:wait_processed()
-  while true do
+  local timeout = 10000
+  local interval = 50
+  local timeout_cnt = timeout / interval
+
+  for _ = 1, timeout_cnt do
     local processing = false
     for _, v in pairs(self._ref_processing) do
       if v then
@@ -83,33 +107,28 @@ function ReferenceTable:wait_processed()
       end
     end
     if not processing then
-      break
+      return
     end
-    vim.wait(50)
+    vim.wait(interval)
   end
+
+  vim.notify("Timeout: ReferenceTable:wait_processed", vim.log.levels.ERROR)
 end
 
 function ReferenceTable:is_processing(path)
   return self._ref_processing[path] ~= nil and not self._ref_processing[path]
 end
 
---- @class ReferenceTable__find_by_key_result
---- @field path string
---- @field t_call FindTExpressionResultItem
-
 --- キーから参照を検索する
 --- @param key string キー
---- @return ReferenceTable__find_by_key_result[]
+--- @return I18n.Ref[]
 function ReferenceTable:find_by_key(key)
   self:wait_processed()
   local result = {}
-  for path, t_calls in pairs(self._ref_table) do
-    for _, t_call in ipairs(t_calls) do
-      if t_call.key == key then
-        table.insert(result, {
-          path = path,
-          t_call = t_call,
-        })
+  for _, refs in pairs(self._ref_table) do
+    for _, ref in ipairs(refs) do
+      if ref.key == key then
+        table.insert(result, ref)
       end
     end
   end

--- a/lua/js-i18n/reference_table.lua
+++ b/lua/js-i18n/reference_table.lua
@@ -1,14 +1,104 @@
+local Path = require("plenary.path")
+local scan = require("plenary.scandir")
+
+local analyzer = require("js-i18n.analyzer")
+local utils = require("js-i18n.utils")
+
+local M = {}
+
 --- 翻訳の参照テーブル
 --- @class I18n.ReferenceTable
+--- @field workspace_dir string ワークスペースディレクトリ
 --- @field _ref_table table<string, table<string, FindTExpressionResultItem[]>>
----
+--- @field _ref_processing table<string, boolean>
+--- @field config I18n.ReferenceTableConfig
 local ReferenceTable = {}
 ReferenceTable.__index = ReferenceTable
 
+--- 設定
+--- @class I18n.ReferenceTableConfig
+--- @field workspace_dir string ワークスペースディレクトリ
+
 --- @return I18n.ReferenceTable
-function ReferenceTable.new()
+function ReferenceTable.new(config)
   local self = setmetatable({}, ReferenceTable)
 
   self._ref_table = {}
+  self._ref_processing = {}
+  self.config = config
   return self
 end
+
+function ReferenceTable:load_all()
+  scan.scan_dir(self.config.workspace_dir, {
+    search_pattern = function(entry)
+      if entry:match("node_modules") then
+        return false
+      end
+      return entry:match("%.jsx?$") or entry:match("%.tsx?$")
+    end,
+    on_insert = function(path)
+      self:load_path(path)
+    end,
+  })
+end
+
+function ReferenceTable:load_path(path)
+  if path == nil or path == "" then
+    return
+  end
+  local lib = utils.detect_library(self.config.workspace_dir)
+
+  self._ref_processing[path] = true
+  vim.schedule(function()
+    local lang = vim.filetype.match({ filename = path }) or "typescriptreact"
+    local content = Path:new(path):read()
+
+    local result = analyzer.find_call_t_expressions_(content, lang, lib)
+    self._ref_table[path] = result
+
+    self._ref_processing[path] = false
+  end)
+end
+
+function ReferenceTable:wait_processed()
+  while true do
+    local processing = false
+    for _, v in pairs(self._ref_processing) do
+      if v then
+        processing = true
+        break
+      end
+    end
+    if not processing then
+      break
+    end
+    vim.wait(100)
+  end
+end
+
+--- @class ReferenceTable__find_by_key_result
+--- @field path string
+--- @field t_call FindTExpressionResultItem
+
+--- キーから参照を検索する
+--- @param key string キー
+--- @return ReferenceTable__find_by_key_result[]
+function ReferenceTable:find_by_key(key)
+  local result = {}
+  for path, t_calls in pairs(self._ref_table) do
+    for _, t_call in ipairs(t_calls) do
+      if t_call.key == key then
+        table.insert(result, {
+          path = path,
+          t_call = t_call,
+        })
+      end
+    end
+  end
+  return result
+end
+
+M.ReferenceTable = ReferenceTable
+
+return M

--- a/lua/js-i18n/translation-source.lua
+++ b/lua/js-i18n/translation-source.lua
@@ -12,6 +12,7 @@ local M = {}
 --- @return string[]
 function M.get_translation_files(dir)
   local result = {}
+  -- OPTIMIZE: pattern は on_insert の中で回すほうがいい
   for _, pattern in ipairs(c.config.translation_source) do
     local regexp = vim.regex(vim.fn.glob2regpat(pattern))
     scan.scan_dir(dir, {

--- a/lua/js-i18n/utils.lua
+++ b/lua/js-i18n/utils.lua
@@ -19,12 +19,10 @@ function M.get_workspace_root(bufnr)
 end
 
 --- 使用しているライブラリを取得する
---- @param bufnr number バッファ番号
+--- @param workspace_dir string プロジェクトのルートディレクトリ
 --- @return string|nil ライブラリの識別子
-function M.detect_library(bufnr)
-  local root = M.get_workspace_root(bufnr)
-
-  local ok, package_json = pcall(vim.fn.readfile, root .. "/package.json")
+function M.detect_library(workspace_dir)
+  local ok, package_json = pcall(vim.fn.readfile, workspace_dir .. "/package.json")
   if not ok then
     return nil
   end

--- a/lua/js-i18n/virt_text.lua
+++ b/lua/js-i18n/virt_text.lua
@@ -62,7 +62,8 @@ function M.set_extmark(bufnr, current_language, t_source)
     return
   end
 
-  local library = utils.detect_library(bufnr)
+  local workspace_dir = utils.get_workspace_root(bufnr)
+  local library = utils.detect_library(workspace_dir)
 
   M.clear_extmarks(bufnr)
 

--- a/lua/js-i18n/virt_text.lua
+++ b/lua/js-i18n/virt_text.lua
@@ -67,7 +67,7 @@ function M.set_extmark(bufnr, current_language, t_source)
 
   M.clear_extmarks(bufnr)
 
-  local t_calls = analyzer.find_call_t_expressions(bufnr)
+  local t_calls = analyzer.find_call_t_expressions_from_buf(bufnr)
 
   for _, t_call in ipairs(t_calls) do
     local key_node = t_call.key_node

--- a/tests/js-i18n/analyzer_spec.lua
+++ b/tests/js-i18n/analyzer_spec.lua
@@ -79,7 +79,7 @@ describe("analyzer.find_call_t_expressions", function()
       vim.cmd("e " .. project.path .. "/test_analyzer/" .. file)
 
       -- Act
-      local result = analyzer.find_call_t_expressions(0)
+      local result = analyzer.find_call_t_expressions_from_buf(0)
 
       local assert_item = function(idx, exp)
         local item = result[idx]
@@ -125,7 +125,7 @@ describe("analyzer.find_call_t_expressions", function()
       vim.api.nvim_buf_set_lines(0, 0, -1, false, vim.split(text, "\n"))
 
       -- Act
-      local result = analyzer.find_call_t_expressions(0)
+      local result = analyzer.find_call_t_expressions_from_buf(0)
 
       -- Assert
       assert.are.equal(expected and 1 or 0, #result)
@@ -228,7 +228,7 @@ describe("analyzer.find_call_t_expressions", function()
       vim.api.nvim_buf_set_lines(0, 0, -1, false, { "t('key1', { value: t('key2') })" })
 
       -- Act
-      local result = analyzer.find_call_t_expressions(0)
+      local result = analyzer.find_call_t_expressions_from_buf(0)
 
       -- Assert
       assert.are.equal(2, #result)


### PR DESCRIPTION
- close: #36 


# Generated by Copilot

This pull request to the `lua/js-i18n` module includes significant changes to improve the handling of source inputs and enhance the functionality of the language server protocol (LSP). The most important changes are grouped into improvements to query handling, LSP enhancements, and utility adjustments.

### Improvements to query handling:
* [`lua/js-i18n/analyzer.lua`](diffhunk://#diff-fab82b4775c895377079312fa62282d5549ec543c3fbcfb07241100d3de54eb4L74-R86): Replaced `bufnr` with a more flexible `source` parameter, which can be either a buffer number or a string source. This change affects multiple functions, including `get_node_for_key`, `parse_get_t`, `parse_call_t`, and `find_call_t_expressions`. [[1]](diffhunk://#diff-fab82b4775c895377079312fa62282d5549ec543c3fbcfb07241100d3de54eb4L74-R86) [[2]](diffhunk://#diff-fab82b4775c895377079312fa62282d5549ec543c3fbcfb07241100d3de54eb4L167-R186) [[3]](diffhunk://#diff-fab82b4775c895377079312fa62282d5549ec543c3fbcfb07241100d3de54eb4L202-R231) [[4]](diffhunk://#diff-fab82b4775c895377079312fa62282d5549ec543c3fbcfb07241100d3de54eb4R248-R255) [[5]](diffhunk://#diff-fab82b4775c895377079312fa62282d5549ec543c3fbcfb07241100d3de54eb4L306-R335)

### LSP enhancements:
* [`lua/js-i18n/lsp/config.lua`](diffhunk://#diff-d7c58276f6e9fdc8b2a3d3e2234f64efc27dba41a2bb2e9114956e2d3cc47249R6-R8): Introduced a reference table for each workspace to manage translation references more effectively.
* `lua/js-i18n/lsp/protocol/notify/text_document_did_change.lua` and `lua/js-i18n/lsp/protocol/notify/text_document_did_open.lua`: Added logic to initialize and update the reference table when documents change or open. [[1]](diffhunk://#diff-67a16c3e49ef365a730b0182be577021a2c94f17f56f10c12ec8ef5e8ccf0a29R1-R23) [[2]](diffhunk://#diff-86c6c009788503e91ed03158193aeedb4ee74496614d1c60d309acbd7a2c0699R1-R20)
* [`lua/js-i18n/lsp/protocol/request/text_document_references.lua`](diffhunk://#diff-715cd7ab6a09cbd90d497150f20a6472be61c88620d0c528f6a4e54985b132fdR1-R39): Implemented a new handler for the `textDocument/references` request to find references of translation keys.
* [`lua/js-i18n/lsp/protocol/request/text_document_definition.lua`](diffhunk://#diff-9ee4aae0b86bf1ba4b26032466dbadb7a00508350051b7178edae38f30bbb88eR17-R20): Updated the definition handler to use content directly instead of creating temporary buffers. [[1]](diffhunk://#diff-9ee4aae0b86bf1ba4b26032466dbadb7a00508350051b7178edae38f30bbb88eR17-R20) [[2]](diffhunk://#diff-9ee4aae0b86bf1ba4b26032466dbadb7a00508350051b7178edae38f30bbb88eL29-R42) [[3]](diffhunk://#diff-9ee4aae0b86bf1ba4b26032466dbadb7a00508350051b7178edae38f30bbb88eL57-R59) [[4]](diffhunk://#diff-9ee4aae0b86bf1ba4b26032466dbadb7a00508350051b7178edae38f30bbb88eL71)

### Utility adjustments:
* [`lua/js-i18n/lsp/checker.lua`](diffhunk://#diff-551baebe4f41242369dac333b1e9072cdd88cce23b0703d1a5be12a57ee0548dL13-R13): Modified the `check` function to use `workspace_dir` instead of `bufnr` for detecting the library. [[1]](diffhunk://#diff-551baebe4f41242369dac333b1e9072cdd88cce23b0703d1a5be12a57ee0548dL13-R13) [[2]](diffhunk://#diff-551baebe4f41242369dac333b1e9072cdd88cce23b0703d1a5be12a57ee0548dL31-R31)
* [`lua/js-i18n/lsp/init.lua`](diffhunk://#diff-fcfae76d673b5f962b309a9d2d88b4ea9397e3426dd8799bceda858a5e1be867R38-R45): Scheduled protocol module handlers to run asynchronously using `vim.schedule`. [[1]](diffhunk://#diff-fcfae76d673b5f962b309a9d2d88b4ea9397e3426dd8799bceda858a5e1be867R38-R45) [[2]](diffhunk://#diff-fcfae76d673b5f962b309a9d2d88b4ea9397e3426dd8799bceda858a5e1be867R57-R60)

These changes collectively enhance the flexibility and performance of the `js-i18n` module, particularly in handling various source inputs and improving LSP functionalities.