### PR TITLE
fix: add support for flattened json

### DIFF
--- a/lua/js-i18n/translation_source.lua
+++ b/lua/js-i18n/translation_source.lua
@@ -264,12 +264,20 @@ function TranslationSource:get_translation(lang, key, library, namespace)
       if text then
         return text, file
       end
+      text = json[table.concat(key, ".")]
+      if text then
+        return text, file
+      end
 
       if library == utils.Library.I18Next then
         for _, suffix in ipairs(c.config.libraries.i18next.plural_suffixes) do
           local key_with_suffix = { unpack(key) }
           key_with_suffix[#key_with_suffix] = key_with_suffix[#key_with_suffix] .. suffix
           text = vim.tbl_get(json, unpack(key_with_suffix))
+          if text then
+            return text, file
+          end
+          text = json[table.concat(key_with_suffix, ".")]
           if text then
             return text, file
           end

--- a/lua/js-i18n/translation_source.lua
+++ b/lua/js-i18n/translation_source.lua
@@ -83,6 +83,15 @@ function M.update_translation(file, key, text)
   -- text に ' が含まれている場合はエスケープする
   text = text:gsub("'", "'\"'\"'")
 
+  local content = vim.fn.readfile(file)
+  local ok, json = pcall(vim.fn.json_decode, content)
+  if ok and type(json) == "table" then
+    local flat_key = table.concat(key, ".")
+    if json[flat_key] ~= nil then
+      key_str = string.format('["%s"]', flat_key)
+    end
+  end
+
   local cmd = string.format(
     "jq '.%s = \"%s\"' %s > %s.tmp && mv %s.tmp %s",
     key_str,


### PR DESCRIPTION
Adds handling of flattened json structures in `TranslationSource.get_translation` as a fallback.

Before this would not work and would throw diagnostic errors even though the translation file could be found:
```json
{
	"some.deeply.nested.key": "value"
}
```
However, this worked fine:
```json
{
	"some": {
		"deeply": {
			"nested": {
				"key": "value"
			} 
		}
	}
}
```

I have also adjusted the `TranslationSource.update_translation` method to handle flattened json. It looks up if the key exists in the root of the json as is `"some.deeply.nested.key"` and falls back to the existing behavior if not.

```lua
  local content = vim.fn.readfile(file)
  local ok, json = pcall(vim.fn.json_decode, content)
  if ok and type(json) == "table" then
    local flat_key = table.concat(key, ".")
    if json[flat_key] ~= nil then
      key_str = string.format('["%s"]', flat_key)
    end
  end
```

--- 

Let me know if i need to adjust anything. And thanks for the plugin btw, it's very useful.
