### PR TITLE
fix: use buffer-local LSP client to support monorepo workspaces

### DIFF
--- a/lua/js-i18n/config.lua
+++ b/lua/js-i18n/config.lua
@@ -2,6 +2,9 @@ local utils = require("js-i18n.utils")
 
 local M = {}
 
+M.SERVER_NAME = "js_i18n"
+M.MINIMUM_SERVER_VERSION = "0.5.0"
+
 --- @class I18n.VirtText.FormatOpts
 --- @field key string
 --- @field value string

--- a/lua/js-i18n/init.lua
+++ b/lua/js-i18n/init.lua
@@ -4,20 +4,15 @@ local virt_text = require("js-i18n.virt_text")
 
 local M = {}
 
-local MINIMUM_SERVER_VERSION = "0.5.0"
-
---- Get the js_i18n LSP client.
---- @return vim.lsp.Client?
-local function get_client()
-  return vim.lsp.get_clients({ name = "js_i18n" })[1]
-end
+local SERVER_NAME = c.SERVER_NAME
+local MINIMUM_SERVER_VERSION = c.MINIMUM_SERVER_VERSION
 
 --- Execute a command on the language server.
 --- @param command string
 --- @param arguments? any[]
 --- @param callback? fun(err: any, result: any)
 local function execute_command(command, arguments, callback)
-  local client = get_client()
+  local client = vim.lsp.get_clients({ name = SERVER_NAME, bufnr = 0 })[1]
   if not client then
     vim.notify("[js-i18n] Language server is not running.", vim.log.levels.WARN)
     return
@@ -128,7 +123,7 @@ M.setup = function(opts)
   vim.api.nvim_set_hl(0, "@i18n.translation", { link = "Comment", default = true })
 
   -- LSP server configuration (Neovim 0.11+)
-  vim.lsp.config["js_i18n"] = {
+  vim.lsp.config[SERVER_NAME] = {
     cmd = cmd,
     filetypes = {
       "javascript",
@@ -161,10 +156,9 @@ M.setup = function(opts)
           vim.log.levels.WARN
         )
       end
-      return true
     end,
   }
-  vim.lsp.enable("js_i18n")
+  vim.lsp.enable(SERVER_NAME)
 
   -- Client-side LSP command handler
   vim.lsp.commands["i18n.executeClientEditTranslation"] = function(command)
@@ -181,7 +175,7 @@ M.setup = function(opts)
     group = group,
     callback = function(ev)
       local client = vim.lsp.get_client_by_id(ev.data.client_id)
-      if not client or client.name ~= "js_i18n" then
+      if not client or client.name ~= SERVER_NAME then
         return
       end
       local value = ev.data.params and ev.data.params.value

--- a/lua/js-i18n/virt_text.lua
+++ b/lua/js-i18n/virt_text.lua
@@ -7,13 +7,14 @@ local M = {}
 --- @type table<integer, uv_timer_t>
 local debounce_timers = {}
 
+local SERVER_NAME = c.SERVER_NAME
 local DEBOUNCE_MS = 200
 
 --- Get the js_i18n LSP client attached to a buffer.
 --- @param bufnr integer
 --- @return vim.lsp.Client?
 local function get_client(bufnr)
-  local clients = vim.lsp.get_clients({ bufnr = bufnr, name = "js_i18n" })
+  local clients = vim.lsp.get_clients({ bufnr = bufnr, name = SERVER_NAME })
   return clients[1]
 end
 


### PR DESCRIPTION
## Summary
- `get_client()` was always returning the first `js_i18n` LSP client regardless of the current buffer. In monorepo setups where each package gets its own LSP client (via `root_markers`), this caused "No translation key found at cursor" errors for any package other than the first one opened.
- Fixed by adding `bufnr = 0` filter to `vim.lsp.get_clients()` so the correct buffer-local client is used.
- Extracted `SERVER_NAME` and `MINIMUM_SERVER_VERSION` constants into `config.lua` for consistency across modules.

## Test plan
- [x] Open files from two different packages in a monorepo
- [x] Verify `I18nEditTranslation` / `I18nCopyKey` works on JSON files in both packages
- [x] Verify virtual text decorations still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)